### PR TITLE
refactor: relocate useFrameworkReady hook into src

### DIFF
--- a/hooks/useFrameworkReady.ts
+++ b/hooks/useFrameworkReady.ts
@@ -1,13 +1,1 @@
-import { useEffect } from 'react';
-
-declare global {
-  interface Window {
-    frameworkReady?: () => void;
-  }
-}
-
-export function useFrameworkReady() {
-  useEffect(() => {
-    window.frameworkReady?.()
-  })
-}
+export { useFrameworkReady } from '@/hooks/useFrameworkReady';

--- a/src/hooks/useFrameworkReady.ts
+++ b/src/hooks/useFrameworkReady.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+
+declare global {
+  interface Window {
+    frameworkReady?: () => void;
+  }
+}
+
+export function useFrameworkReady() {
+  useEffect(() => {
+    window.frameworkReady?.();
+  });
+}


### PR DESCRIPTION
## Summary
- move the useFrameworkReady hook implementation into src/hooks so it can be resolved via the @/ alias
- keep the legacy hooks module as a re-export to preserve existing import paths outside of src

## Testing
- npm run -s lint *(fails: existing lint errors and warnings in unrelated files such as app/_layout.tsx and src/contexts/SupabaseAuthContext.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68dcab0246708320a0b454591dca5a8a